### PR TITLE
STM32F4_DISCO Make it work with latest mbed.

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -19,7 +19,10 @@ modules:
     rtos_cortex_m4: &rtos_cortex_m4
         - tools/records/rtos/rtos_cortex_m4.yaml
         - tools/records/rtos/rtos_common.yaml
-
+    mbed_f407xx_lib: &module_mbed_f407xx_lib
+        - tools/records/mbed/disco_f407vg/disco_f407vg_cmsis.yaml
+        - tools/records/mbed/disco_f407vg/disco_f407vg_target.yaml
+ 
 projects:
     k20d50m_blinky:
         - *module_mbed
@@ -57,8 +60,7 @@ projects:
     disco_f407vg_blinky:
         - *module_mbed
         - *mbed_toolchain_settings
-        - tools/records/mbed/disco_f407vg/disco_f407vg_cmsis.yaml
-        - tools/records/mbed/disco_f407vg/disco_f407vg_target.yaml
+        - *module_mbed_f407xx_lib
         - tools/records/projects/disco_f407vg_blinky.yaml
 
 # workspace showcase, where we can group multiple projects
@@ -82,6 +84,10 @@ settings:
         uvision:
             template:
                 - tools/records/templates/template.uvproj
+        gcc:
+            path:
+                - /opt/gnu-mcu-eclipse/arm-none-eabi-gcc/current/bin/
+
     # change default output dir (generated_projects to a path with keywords)
     # export_dir:
     #     - generated_projects/{target}/{project_name}/{tool}

--- a/tools/records/mbed/disco_f407vg/disco_f407vg_cmsis.yaml
+++ b/tools/records/mbed/disco_f407vg/disco_f407vg_cmsis.yaml
@@ -1,10 +1,12 @@
 common:
     includes:
         - mbed/libraries/mbed/targets/cmsis
-        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F407VG
+        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4
+        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG
     sources:
         stm32f407vg:
-        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F407VG
+        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4
+        - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG
 tool_specific:
     uvision:
         includes:
@@ -18,9 +20,9 @@ tool_specific:
     gcc_arm:
         sources:
             stm32f407vg:
-            - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/startup_stm32f407xx.s
+            - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/startup_stm32f407xx.s
         linker_file:
-            - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/STM32F407.ld
+            - mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
     iar:
         sources:
             stm32f407vg:

--- a/tools/records/mbed/disco_f407vg/disco_f407vg_target.yaml
+++ b/tools/records/mbed/disco_f407vg/disco_f407vg_target.yaml
@@ -1,10 +1,11 @@
 common:
     includes:
-        - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG
-        - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG/TARGET_DISCO_F407VG
+        - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4
+        - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/
     sources:
-        disco_f407vg_hal:
-            - mbed\libraries\mbed\targets\hal\TARGET_STM\TARGET_STM32F407VG
+        stm32f407vg:
+            - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4
+            - mbed/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/
     macros:
         - TARGET_DISCO_F407VG
         - TARGET_M4


### PR DESCRIPTION
I made your great project work with the latest mbed (Hash: 1f340445d5333b485923beb9a7216fc54a8efeb4) for the STM32F4 discovery kit.
One little question:
- In the file disco_f407vg_cmsis.yaml line 8/9 is there a better way to define the stm32f4 generic files in (mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4) and the stm32f407vg specific files (mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG).

I think it is not nice that both folders are only included if the target mcu is stm32f407vg.